### PR TITLE
fix: skip cargo package/publish when not releasing to crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,5 @@ jobs:
           RUST_BACKTRACE: 1
           GH_USERNAME: ${{ github.actor }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }}
           GIT_COMMITTER_NAME: semantic-rs
           GIT_COMMITTER_EMAIL: semantic-rs@users.noreply.github.com

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,9 +198,11 @@ fn package_crate(config: &config::Config, repository_path: &str, new_version: &s
     git::commit_files(config, new_version)
         .unwrap_or_else(|err| error!("Committing files failed: {:?}", err));
 
-    info!("Package crate");
-    if !cargo::package(repository_path) {
-        error!("`cargo package` failed. See above for the cargo error message.");
+    if config.can_release_to_cratesio() {
+        info!("Package crate");
+        if !cargo::package(repository_path) {
+            error!("`cargo package` failed. See above for the cargo error message.");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Guard `cargo package` behind `config.can_release_to_cratesio()` in `package_crate()` — the call was unconditional and failed because `clog`'s git dependency has no version spec, which `cargo package` requires
- Remove `CARGO_TOKEN` from the CI workflow so `can_release_to_cratesio()` returns `false` and neither `cargo package` nor `cargo publish` is ever invoked

## Why
This fork releases to GitHub + GHCR only, not crates.io. The `cargo package` step is only needed as a pre-flight for `cargo publish`, so it should be skipped when no crates.io token is configured.

## Test plan
- [ ] CI `check` job passes (fmt, clippy, test)
- [ ] CI `release` job runs without `cargo package` errors
- [ ] On tag push, `build.yml` cross-compiles, pushes Docker image to GHCR, and uploads binaries to the GitHub release