### PR TITLE
fix: pass --repo to gh release upload to avoid git repo requirement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,7 @@ jobs:
           gh release upload "${{ github.ref_name }}" \
             artifacts/semantic-rs-linux-amd64/semantic-rs-linux-amd64 \
             artifacts/semantic-rs-linux-arm64/semantic-rs-linux-arm64 \
+            --repo "${{ github.repository }}" \
             --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `--repo ${{ github.repository }}` to the `gh release upload` command in the `upload` job

## Why
The `upload` job does not check out the repository, so there is no `.git` directory and `gh` cannot infer which repo to operate on. Passing `--repo` directly avoids the need for a checkout step.